### PR TITLE
Highlight individual changed scripts, fix Windows bugs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,6 +95,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dunce"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56ce8c6da7551ec6c462cbaf3bfbc75131ebbfa1c944aeaa9dab51ca1c5f0c3b"
+
+[[package]]
 name = "either"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -314,6 +320,7 @@ checksum = "f98d2aa92eebf49b69786be48e4477826b256916e84a57ff2a4f21923b48eb4c"
 name = "scratch-git"
 version = "0.1.0"
 dependencies = [
+ "dunce",
  "itertools",
  "regex",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,4 @@ zip = { version = "0.6.6", default-features = false, features = ["deflate"] }
 tungstenite = "0.21.0"
 regex = "1.10.4"
 itertools = "0.12.1"
+dunce = "1.0.4"

--- a/src-frontend/api.ts
+++ b/src-frontend/api.ts
@@ -46,7 +46,13 @@ export class Socket extends WebSocket {
   receive(): Promise<any> {
     return new Promise((resolve, reject) => {
       this.onmessage = (message) => {
-        return resolve(JSON.parse(message.data));
+        try {
+          let json = JSON.parse(message.data);
+          return resolve(json);
+        } catch (e: any) {
+          console.log(e.stack);
+          throw new Error(message.data);
+        }
       };
 
       this.onerror = (error) => {

--- a/src-frontend/diff-indicators.ts
+++ b/src-frontend/diff-indicators.ts
@@ -3,6 +3,7 @@ import { type Project } from "./api";
 import { Cmp } from "./dom/index";
 import van from "vanjs-core";
 import { DiffModal } from "./modals/diff";
+import { diff, parseScripts } from "./modals/diff/utils";
 
 const { div, i } = van.tags;
 
@@ -55,10 +56,70 @@ const StageDiff = (props: {}) =>
     )
   );
 
+/** Receive Blockly IDs to top-level blocks that were changed */
+async function changedBlocklyScripts(
+  project: Project,
+  sprite: (string | boolean)[],
+  loadedJSON: any
+) {
+  let spriteName: string = sprite[0] + (sprite[1] ? " (stage)" : "");
+  let currentScripts = await project.getCurrentScripts(spriteName);
+
+  let scripts = parseScripts(
+    await project.getPreviousScripts(spriteName),
+    currentScripts
+  );
+
+  let diffs = (
+    await Promise.all(
+      scripts.results.map((script) => {
+        return diff(script.oldContent, script.newContent);
+      })
+    )
+  )
+    .map((diffed, i) => ({ ...diffed, ...scripts.results[i] }))
+    .filter((result) => result.diffed !== "" && result.status !== "error");
+
+  let target = loadedJSON.targets.find((e: any) =>
+    spriteName.includes("(stage)") ? e.isStage : e.name === spriteName
+  );
+
+  let topLevels = Object.keys(target.blocks).filter(
+    (k) => target.blocks[k].parent === null
+  );
+  return diffs
+    .map(
+      (e) =>
+        window.Blockly.getMainWorkspace().topBlocks_[
+          topLevels.indexOf(e.script)
+        ]?.id
+    )
+    .filter((e) => e !== undefined);
+}
+
+/** Applies a diff block glow similar to the glow that displays while a script runs */
+function applyDiffFilter() {
+  if (document.querySelector("filter#blocklyStackDiffFilter")) return;
+
+  let defs = document.querySelector(".blocklySvg defs")!;
+  defs.innerHTML += `<filter id="blocklyStackDiffFilter" height="160%" width="180%" y="-30%" x="-40%">
+    <feGaussianBlur in="SourceGraphic" stdDeviation="4"></feGaussianBlur>
+    <feComponentTransfer result="outBlur">
+      <feFuncA type="table" tableValues="0 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1"></feFuncA>
+    </feComponentTransfer>
+    <feFlood flood-color="#FFF200" flood-opacity="1" result="outColor"></feFlood>
+    <feComposite in="outColor" in2="outBlur" operator="in" result="outGlow"></feComposite>
+    <feComposite in="SourceGraphic" in2="outGlow" operator="over"></feComposite>
+  </filter>`;
+}
+
 export async function showIndicators(project: Project) {
   let changedSprites = await project.getSprites();
-  // @ts-ignore
-  let sprites = [...document.querySelector(`.${Cmp.SPRITES}`).children];
+  let sprites = [...document.querySelector(`.${Cmp.SPRITES}`)!.children];
+  let loadedJSON = JSON.parse(window.vm.toJSON());
+
+  const nameOfSprite = (element: HTMLElement) =>
+    element.querySelectorAll("div")[2].innerText;
 
   sprites.forEach((sprite) => {
     let divs = sprite
@@ -123,10 +184,33 @@ export async function showIndicators(project: Project) {
         }
       );
       diffButton.style.marginTop =
-        changedSpriteElement.querySelectorAll("div")[2].innerText === spriteName
-          ? "30px"
-          : "0px";
+        nameOfSprite(changedSpriteElement) === spriteName ? "30px" : "0px";
+      (
+        await changedBlocklyScripts(
+          project,
+          changedSprites.find((e) => e[0] === spriteName)!,
+          loadedJSON
+        )
+      ).forEach((e) => {
+        console.log(
+          window.Blockly.getMainWorkspace().getBlockById(e).svgGroup_
+        );
+      });
     });
+  });
+
+  let selectedSpriteName = nameOfSprite(
+    document.querySelector(`.${Cmp.SELECTED_SPRITE}`)!
+  );
+  (
+    await changedBlocklyScripts(
+      project,
+      changedSprites.find((e) => e[0] === selectedSpriteName)!,
+      loadedJSON
+    )
+  ).forEach((e) => {
+    let group = window.Blockly.getMainWorkspace().getBlockById(e).svgGroup_;
+    group.style = "filter: drop-shadow(3px 5px 2px rgb(0 0 0 / 0.4))";
   });
 
   // creates a diff button for the stage
@@ -162,7 +246,7 @@ export async function showIndicators(project: Project) {
     stageWrapper.querySelector("img")!.after(stageDiffButton);
   }
 
-  stageWrapper.onclick = () => {
+  stageWrapper.onclick = async () => {
     (<HTMLDivElement[]>[
       ...document.querySelectorAll(
         `.${Cmp.DELETE_BUTTON}.${Cmp.SELECTOR_ITEM_DELETE_BUTTON}`
@@ -170,5 +254,12 @@ export async function showIndicators(project: Project) {
     ])
       .filter((button) => !button.classList.contains("stage-diff-button"))
       .forEach((button) => (button.style.marginTop = "0px"));
+    (await changedBlocklyScripts(project, ["Stage", true], loadedJSON)).forEach(
+      (e) => {
+        console.log(
+          window.Blockly.getMainWorkspace().getBlockById(e).svgGroup_
+        );
+      }
+    );
   };
 }

--- a/src-frontend/diff-indicators.ts
+++ b/src-frontend/diff-indicators.ts
@@ -97,7 +97,7 @@ async function changedBlocklyScripts(
     .filter((e) => e !== undefined);
 }
 
-/** Applies a diff block glow similar to the glow that displays while a script runs */
+/** Applies a diff block glow that displays while a script runs */
 function applyDiffFilter() {
   if (document.querySelector("filter#blocklyStackDiffFilter")) return;
 
@@ -107,12 +107,13 @@ function applyDiffFilter() {
     <feComponentTransfer result="outBlur">
       <feFuncA type="table" tableValues="0 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1"></feFuncA>
     </feComponentTransfer>
-    <feFlood flood-color="#FFF200" flood-opacity="1" result="outColor"></feFlood>
+    <feFlood flood-color="#b10d99" flood-opacity="1" result="outColor"></feFlood>
     <feComposite in="outColor" in2="outBlur" operator="in" result="outGlow"></feComposite>
     <feComposite in="SourceGraphic" in2="outGlow" operator="over"></feComposite>
   </filter>`;
 }
 
+/** Shows buttons to display changes and highlight changed scripts */
 export async function showIndicators(project: Project) {
   let changedSprites = await project.getSprites();
   let sprites = [...document.querySelector(`.${Cmp.SPRITES}`)!.children];
@@ -185,6 +186,7 @@ export async function showIndicators(project: Project) {
       );
       diffButton.style.marginTop =
         nameOfSprite(changedSpriteElement) === spriteName ? "30px" : "0px";
+      applyDiffFilter();
       (
         await changedBlocklyScripts(
           project,
@@ -202,6 +204,7 @@ export async function showIndicators(project: Project) {
   let selectedSpriteName = nameOfSprite(
     document.querySelector(`.${Cmp.SELECTED_SPRITE}`)!
   );
+  applyDiffFilter();
   (
     await changedBlocklyScripts(
       project,
@@ -210,7 +213,7 @@ export async function showIndicators(project: Project) {
     )
   ).forEach((e) => {
     let group = window.Blockly.getMainWorkspace().getBlockById(e).svgGroup_;
-    group.style = "filter: drop-shadow(3px 5px 2px rgb(0 0 0 / 0.4))";
+    group.setAttribute("filter", "url(#blocklyStackDiffFilter)");
   });
 
   // creates a diff button for the stage
@@ -254,6 +257,7 @@ export async function showIndicators(project: Project) {
     ])
       .filter((button) => !button.classList.contains("stage-diff-button"))
       .forEach((button) => (button.style.marginTop = "0px"));
+    applyDiffFilter();
     (await changedBlocklyScripts(project, ["Stage", true], loadedJSON)).forEach(
       (e) => {
         console.log(

--- a/src-frontend/initialize.ts
+++ b/src-frontend/initialize.ts
@@ -62,7 +62,7 @@ export default async function () {
   const displayDiffs = async () => {
     [
       ...document.querySelectorAll(`.diff-button`),
-      ...document.querySelectorAll(`.stage-diff-button`),
+      ...document.querySelectorAll(`.stage-diff`),
     ].forEach((e) => e.remove());
     let project = await api.getCurrentProject()!;
     await project!.unzip();

--- a/src-frontend/main.ts
+++ b/src-frontend/main.ts
@@ -6,6 +6,7 @@ declare global {
     vm: any;
     scratchblocks: any;
     parseSB3Blocks: any;
+    Blockly: any;
   }
 }
 

--- a/src-frontend/media/bars.css
+++ b/src-frontend/media/bars.css
@@ -40,12 +40,6 @@
             &:hover {
                 background-color: #ccd3dd;
             }
-
-            & .active-tab {
-                color: var(--menu-bar-background-default);
-                background-color: white;
-                outline: none;
-            }
         }
     }
 
@@ -67,6 +61,12 @@
         margin-top: 10px;
         overflow-x: hidden;
     }
+}
+
+.active-tab {
+    color: var(--menu-bar-background-default) !important;
+    background-color: white !important;
+    outline: none;
 }
 
 .display-error {

--- a/src-frontend/modals/diff/index.ts
+++ b/src-frontend/modals/diff/index.ts
@@ -131,10 +131,12 @@ export class DiffModal extends HTMLDialogElement {
     // not sure why all this isn't just done by diff()
     const diffs = (
       await Promise.all(
-        scripts.map((script) => diff(script.oldContent, script.newContent))
+        scripts.results.map((script) =>
+          diff(script.oldContent, script.newContent)
+        )
       )
     )
-      .map((diffed, i) => ({ ...diffed, ...scripts[i] }))
+      .map((diffed, i) => ({ ...diffed, ...scripts.results[i] }))
       .filter((result) => result.diffed !== "" || result.status === "error");
 
     if (diffs[script].status === "error") {

--- a/src-server/handlers.rs
+++ b/src-server/handlers.rs
@@ -38,7 +38,7 @@ enum CommandData<'a> {
         old_content: String,
         new_content: String,
     },
-    FilePath(&'a str),
+    FilePath(String),
 }
 
 #[derive(Serialize, Deserialize)]
@@ -63,7 +63,7 @@ impl Cmd<'_> {
         let CommandData::FilePath(file_name) = data else {
             return json!({});
         };
-        let binding = Path::new(file_name)
+        let binding = Path::new(&file_name)
             .file_name()
             .unwrap()
             .to_os_string()
@@ -123,13 +123,20 @@ impl Cmd<'_> {
         )
         .unwrap();
 
-        let init_repo = Command::new("git")
-            .args(["init"])
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .current_dir(&project_path)
-            .output()
-            .expect("failed to intialize git repo");
+        let init_repo = if cfg!(target_os = "windows") {
+            let mut cmd = Command::new("cmd");
+            cmd.args(["/C", "git", "init"]);
+            cmd
+        } else {
+            let mut git = Command::new("git");
+            git.arg("init");
+            git
+        }
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .current_dir(&project_path)
+        .output()
+        .expect("failed to intialize git repo");
         if !String::from_utf8(init_repo.stdout)
             .unwrap()
             .contains("Git repository")
@@ -137,24 +144,24 @@ impl Cmd<'_> {
             return json!({ "project_name": "fail" });
         }
 
-        if !Command::new("git")
-            .args(["add", "."])
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .current_dir(&project_path)
-            .status()
-            .unwrap()
-            .success()
-        {
+        if !git::add(&project_path) {
             return json!({ "project_name": "fail" });
         }
 
-        let mut git = Command::new("git");
-        let commit = git
-            .args(["commit", "-m", "Initial commit"])
+        let mut commit = if cfg!(target_os = "windows") {
+            let mut cmd = Command::new("cmd");
+            cmd.args(["/C", "git", "commit", "-m", "Initial commit"]);
+            cmd
+        } else {
+            let mut git = Command::new("git");
+            git.args(["commit", "-m", "Initial commit"]);
+            git
+        };
+        let commit = commit
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
             .current_dir(project_path);
+
         if !String::from_utf8(commit.output().unwrap().stdout)
             .unwrap()
             .contains("Initial commit")
@@ -247,14 +254,32 @@ impl Cmd<'_> {
             return json!({});
         };
         let pth = get_project_path(&project_config().lock().unwrap().projects, &project_name);
-        json!({ "status": if !Command::new("git")
-            .arg("push")
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .current_dir(&pth)
-            .status()
-            .unwrap()
-            .success() { "fail" } else { "success" } })
+        #[cfg(target_os = "windows")]
+        {
+            let mut cmd = Command::new("cmd");
+            let push = cmd
+                .args(["/C", "git", "push"])
+                .stdout(Stdio::piped())
+                .stderr(Stdio::piped())
+                .current_dir(&pth);
+            json!({ "status": if !push
+                .status()
+                .unwrap()
+                .success() { "fail" } else { "success" } })
+        }
+        #[cfg(unix)]
+        {
+            let mut git = Command::new("git");
+            let push = git
+                .arg("push")
+                .stdout(Stdio::piped())
+                .stderr(Stdio::piped())
+                .current_dir(&pth);
+            json!({ "status": if !push
+                .status()
+                .unwrap()
+                .success() { "fail" } else { "success" } })
+        }
     }
 
     fn commit(data: CommandData) -> Value {
@@ -262,9 +287,10 @@ impl Cmd<'_> {
             return json!({});
         };
 
-        let pth = get_project_path(&project_config().lock().unwrap().projects, &project_name);
+        let project_path =
+            get_project_path(&project_config().lock().unwrap().projects, &project_name);
         let _current_project = serde_json::from_str::<serde_json::Value>(
-            &fs::read_to_string(pth.join("project.old.json"))
+            &fs::read_to_string(project_path.join("project.old.json"))
                 .unwrap()
                 .as_str(),
         )
@@ -272,7 +298,7 @@ impl Cmd<'_> {
         let current_diff = Diff::new(&_current_project);
 
         let _new_project = serde_json::from_str::<serde_json::Value>(
-            &fs::read_to_string(pth.join("project.json"))
+            &fs::read_to_string(project_path.join("project.json"))
                 .unwrap()
                 .as_str(),
         )
@@ -280,35 +306,30 @@ impl Cmd<'_> {
         let new_diff = Diff::new(&_new_project);
 
         for change in new_diff.costumes(&current_diff) {
-            fs::remove_file(pth.join(change.costume_path)).expect("failed to remove asset");
+            fs::remove_file(project_path.join(change.costume_path))
+                .expect("failed to remove asset");
         }
 
-        if !Command::new("git")
-            .args(["add", "."])
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .current_dir(&pth)
-            .status()
-            .unwrap()
-            .success()
-        {
+        if !git::add(&project_path) {
             return json!({ "message": "fail" });
         }
 
-        let mut git = Command::new("git");
-        let commit = git.args(["commit", "-m", "temporary"]).current_dir(&pth);
-
-        if !commit.status().unwrap().success() {
-            return json!({ "message": "fail" });
-        }
-
-        let previous_revision = Diff::from_revision(&pth, "HEAD~1:project.json");
+        let previous_revision = Diff::from_revision(&project_path, "HEAD~1:project.json");
         let commit_message = previous_revision.commits(&new_diff).join(", ");
 
-        let mut git = Command::new("git");
-        let commit = git
-            .args(["commit", "--amend", "-m", &commit_message])
-            .current_dir(&pth);
+        let mut commit = if cfg!(target_os = "windows") {
+            let mut cmd = Command::new("cmd");
+            cmd.args(["/C", "git", "commit", "--amend", "-m", &commit_message]);
+            cmd
+        } else {
+            let mut git = Command::new("git");
+            git.args(["commit", "--amend", "-m", &commit_message]);
+            git
+        };
+        let commit = commit
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .current_dir(project_path);
 
         if !commit.status().unwrap().success() {
             return json!({ "message": "fail" });
@@ -322,13 +343,22 @@ impl Cmd<'_> {
             return json!({});
         };
         let pth = get_project_path(&project_config().lock().unwrap().projects, &project_name);
+        let format = "--pretty=format:{\"commit\": \"%H\", \"subject\": \"%s\", \"body\": \"%b\", \"author\": {\"name\": \"%aN\", \"email\": \"%aE\", \"date\": \"%aD\"}},";
 
-        let git_log = Command::new("git")
-            .args([
-                "log",
-                &("--pretty=format:".to_owned()+
-                "{\"commit\": \"%H\", \"subject\": \"%s\", \"body\": \"%b\", \"author\": {\"name\": \"%aN\", \"email\": \"%aE\", \"date\": \"%aD\"}},")
-            ]).current_dir(pth).output().unwrap().stdout;
+        let git_log = if cfg!(target_os = "windows") {
+            let mut cmd = Command::new("cmd");
+            cmd.args(["/C", "git", "log", format]);
+            cmd
+        } else {
+            let mut git = Command::new("git");
+            git.args(["log", format]);
+            git
+        }
+        .current_dir(pth)
+        .output()
+        .unwrap()
+        .stdout;
+
         let binding = String::from_utf8(git_log).unwrap();
         let binding = if binding.as_str().matches("\"commit\"").count() > 1 {
             format!(
@@ -358,7 +388,7 @@ impl Cmd<'_> {
         let project_old_json = match binding {
             Ok(fh) => fh.as_str(),
             Err(_) => {
-                return json!({ "status": "you forgot to unzip the project dingus" });
+                return json!({ "status": "unzip the project first that should do it" });
             }
         };
         let _current_project = serde_json::from_str::<serde_json::Value>(project_old_json).unwrap();

--- a/src-server/utils/git.rs
+++ b/src-server/utils/git.rs
@@ -145,5 +145,5 @@ pub fn add(cwd: &PathBuf) -> bool {
         .stderr(Stdio::piped())
         .current_dir(&cwd);
 
-    return !add.status().unwrap().success();
+    return add.status().unwrap().success();
 }

--- a/src-server/utils/git.rs
+++ b/src-server/utils/git.rs
@@ -5,12 +5,25 @@ use std::process::{Command, Stdio};
 
 /// Return a generated blob ID from a string
 fn git_object_id(content: String) -> String {
-    let mut child = Command::new("git")
-        .args(["hash-object", "-w", "--stdin"])
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .spawn()
-        .expect("failed to open git hash-object");
+    // let mut child = Command::new("git")
+    //     .args(["hash-object", "-w", "--stdin"])
+    //     .stdin(Stdio::piped())
+    //     .stdout(Stdio::piped())
+    //     .spawn()
+    //     .expect("failed to open git hash-object");
+    let mut child = if cfg!(target_os = "windows") {
+        let mut cmd = Command::new("cmd");
+        cmd.args(["/C", "git", "hash-object", "w", "--stdin"]);
+        cmd
+    } else {
+        let mut git = Command::new("git");
+        git.args(["hash-object", "-w", "--stdin"]);
+        git
+    }
+    .stdin(Stdio::piped())
+    .stdout(Stdio::piped())
+    .spawn()
+    .expect("failed to open git hash-object");
     let mut stdin = child.stdin.take().expect("failed to open stdin");
     std::thread::spawn(move || {
         stdin
@@ -45,11 +58,18 @@ pub fn diff(mut old_content: String, mut new_content: String) -> GitDiff {
     }
     let old_id = git_object_id(old_content.into());
     let new_id = git_object_id(new_content.into());
-    let proc = Command::new("git")
-        .args(["diff", "--no-color", &old_id, &new_id])
-        .stdout(Stdio::piped())
-        .spawn()
-        .expect("failed to run git diff");
+    let proc = if cfg!(target_os = "windows") {
+        let mut cmd = Command::new("cmd");
+        cmd.args(["/C", "git", "diff", "--no-color", &old_id, &new_id]);
+        cmd
+    } else {
+        let mut git = Command::new("git");
+        git.args(["diff", "--no-color", &old_id, &new_id]);
+        git
+    }
+    .stdout(Stdio::piped())
+    .spawn()
+    .expect("failed to spawn git diff");
     let output = &proc.wait_with_output().expect("failed to access output");
     let output = String::from_utf8_lossy(&output.stdout);
     let binding = &output.trim().split("@@").into_iter().collect::<Vec<_>>()[2..];
@@ -93,12 +113,37 @@ pub fn diff(mut old_content: String, mut new_content: String) -> GitDiff {
 }
 
 pub fn show_revision(cwd: &PathBuf, commit: &str) -> String {
-    let proc = Command::new("git")
-        .args(["show", commit])
-        .stdout(Stdio::piped())
-        .current_dir(cwd)
-        .spawn()
-        .expect("failed to run git show");
+    let proc = if cfg!(target_os = "windows") {
+        let mut cmd = Command::new("cmd");
+        cmd.args(["/C", "git", "show", commit]);
+        cmd
+    } else {
+        let mut git = Command::new("git");
+        git.args(["show", commit]);
+        git
+    }
+    .current_dir(cwd)
+    .spawn()
+    .expect("failed to spawn git show");
     let output = &proc.wait_with_output().expect("failed to access output");
     String::from_utf8_lossy(&output.stdout).to_string()
+}
+
+/// Stages all files in a Git project - returns true if the command was successful
+pub fn add(cwd: &PathBuf) -> bool {
+    let mut add = if cfg!(target_os = "windows") {
+        let mut cmd = Command::new("cmd");
+        cmd.args(["/C", "git", "add", "."]);
+        cmd
+    } else {
+        let mut git = Command::new("git");
+        git.args(["add", "."]);
+        git
+    };
+    let add = add
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .current_dir(&cwd);
+
+    return !add.status().unwrap().success();
 }

--- a/src-server/utils/git.rs
+++ b/src-server/utils/git.rs
@@ -5,15 +5,9 @@ use std::process::{Command, Stdio};
 
 /// Return a generated blob ID from a string
 fn git_object_id(content: String) -> String {
-    // let mut child = Command::new("git")
-    //     .args(["hash-object", "-w", "--stdin"])
-    //     .stdin(Stdio::piped())
-    //     .stdout(Stdio::piped())
-    //     .spawn()
-    //     .expect("failed to open git hash-object");
     let mut child = if cfg!(target_os = "windows") {
         let mut cmd = Command::new("cmd");
-        cmd.args(["/C", "git", "hash-object", "w", "--stdin"]);
+        cmd.args(["/C", "git", "hash-object", "-w", "--stdin"]);
         cmd
     } else {
         let mut git = Command::new("git");
@@ -145,5 +139,5 @@ pub fn add(cwd: &PathBuf) -> bool {
         .stderr(Stdio::piped())
         .current_dir(&cwd);
 
-    return add.status().unwrap().success();
+    return !add.status().unwrap().success();
 }

--- a/src-server/utils/git.rs
+++ b/src-server/utils/git.rs
@@ -117,10 +117,9 @@ pub fn show_revision(cwd: &PathBuf, commit: &str) -> String {
         git
     }
     .current_dir(cwd)
-    .spawn()
+    .output()
     .expect("failed to spawn git show");
-    let output = &proc.wait_with_output().expect("failed to access output");
-    String::from_utf8_lossy(&output.stdout).to_string()
+    String::from_utf8_lossy(&proc.stdout).to_string()
 }
 
 /// Stages all files in a Git project - returns true if the command was successful
@@ -139,5 +138,5 @@ pub fn add(cwd: &PathBuf) -> bool {
         .stderr(Stdio::piped())
         .current_dir(&cwd);
 
-    return !add.status().unwrap().success();
+    return add.status().unwrap().success();
 }


### PR DESCRIPTION
I don't really test on anything besides Linux so these bugs remained hidden for a while haha

Anyways here's what was fixed:
- Windows paths can be used for projects upon creation
- Make all the git commands run through cmd.exe on Windows (and replace `fs::canonicalize` with `dunce::canonicalize`)